### PR TITLE
add deepspeed support

### DIFF
--- a/deepspeed.sh
+++ b/deepspeed.sh
@@ -1,10 +1,10 @@
 CUBLAS_WORKSPACE_CONFIG=:4096:8
-export CUDA_VISIBLE_DEVICES=4,5
+
 
 torchrun --nproc_per_node=2 --master_port 10101  main.py \
     --dataset_config configs/pretrain_test_flickr_only.json \
     --deepspeed_config deepspeed_config.json \
-    --batch_size 4 \
+    --batch_size 2 \
     --lr_backbone 2e-5 \
     --text_encoder_lr 2e-5 \
     --lr 1e-4 \
@@ -17,5 +17,6 @@ torchrun --nproc_per_node=2 --master_port 10101  main.py \
     --ema \
     --output-dir output/$exp_id \
     --distributed \
-    --load /data2/users/lcmql/unitab/weights/pretrained_checkpoint.pth \
+    --load /path/to/unitab/weights/pretrained_checkpoint.pth \
     --from_deepspeed \
+    --mem_cap 16 \

--- a/deepspeed.sh
+++ b/deepspeed.sh
@@ -1,0 +1,21 @@
+CUBLAS_WORKSPACE_CONFIG=:4096:8
+export CUDA_VISIBLE_DEVICES=4,5
+
+torchrun --nproc_per_node=2 --master_port 10101  main.py \
+    --dataset_config configs/pretrain_test_flickr_only.json \
+    --deepspeed_config deepspeed_config.json \
+    --batch_size 4 \
+    --lr_backbone 2e-5 \
+    --text_encoder_lr 2e-5 \
+    --lr 1e-4 \
+    --num_queries 200 \
+    --max_decoding_step 256 \
+    --do_caption \
+    --no_detection \
+    --unitab_pretrain \
+    --pretrain_seqcrop mixed \
+    --ema \
+    --output-dir output/$exp_id \
+    --distributed \
+    --load /data2/users/lcmql/unitab/weights/pretrained_checkpoint.pth \
+    --from_deepspeed \

--- a/deepspeed_config.json
+++ b/deepspeed_config.json
@@ -1,0 +1,9 @@
+{
+  "zero_optimization": {
+    "stage": 2
+  },
+  "train_batch_size": 4,
+  "fp16": {
+    "enable": true
+  }
+}

--- a/deepspeed_config.json
+++ b/deepspeed_config.json
@@ -1,9 +1,19 @@
 {
   "zero_optimization": {
-    "stage": 2
-  },
-  "train_batch_size": 4,
+    "stage": 2,
+    "offload_param": {
+      "device": "cpu"
+    },
+    "offload_optimizer": {
+      "device": "cpu"
+    }
+    },
+  "activation_checkpointing": {
+    "partition_activations": true
+    },
+  "train_batch_size": 12,
   "fp16": {
-    "enable": true
+    "enabled": true,
+    "loss_scale": 0
   }
 }

--- a/main.py
+++ b/main.py
@@ -34,8 +34,6 @@ from colossalai.logging import disable_existing_loggers, get_dist_logger
 from colossalai.utils import save_checkpoint
 from colossalai.zero.init_ctx import ZeroInitContext
 from colossalai.zero.shard_utils import BucketTensorShardStrategy, TensorShardStrategy
-
-
 from colossalai.gemini import GeminiManager
 from colossalai.gemini.chunk import ChunkManager
 from colossalai.utils.model.colo_init_context import ColoInitContext
@@ -230,7 +228,6 @@ def main(args):
                         host=args.host,
                         port=args.port,
                         backend=args.backend)
-
     elif args.distributed:
         print("init distributed mode from torch")
         dist.init_distributed_mode(args)

--- a/util/dist.py
+++ b/util/dist.py
@@ -222,11 +222,11 @@ def init_distributed_mode(args, port=12345):
     args.dist_backend = "nccl"
     print("| distributed init (rank {}): {}".format(args.rank, args.dist_url), flush=True)
 
-
-    #dist.init_process_group(
-    #    backend=args.dist_backend, init_method=args.dist_url, world_size=args.world_size, rank=args.rank, timeout=timedelta(days=10),
-    #)
-
-    deepspeed.init_distributed()
+    if not args.from_deepspeed:
+        dist.init_process_group(
+            backend=args.dist_backend, init_method=args.dist_url, world_size=args.world_size, rank=args.rank, timeout=timedelta(days=10),
+        )
+    else:
+        deepspeed.init_distributed()
     dist.barrier()
     setup_for_distributed(args.rank == 0)

--- a/util/dist.py
+++ b/util/dist.py
@@ -200,7 +200,7 @@ def save_on_master(*args, **kwargs):
     if is_main_process():
         torch.save(*args, **kwargs)
 
-
+import deepspeed
 def init_distributed_mode(args, port=12345):
     """Initialize distributed training, if appropriate"""
     from datetime import timedelta
@@ -222,9 +222,11 @@ def init_distributed_mode(args, port=12345):
     args.dist_backend = "nccl"
     print("| distributed init (rank {}): {}".format(args.rank, args.dist_url), flush=True)
 
-    dist.init_process_group(
-        backend=args.dist_backend, init_method=args.dist_url, world_size=args.world_size, rank=args.rank, timeout=timedelta(days=10),
-    )
 
+    #dist.init_process_group(
+    #    backend=args.dist_backend, init_method=args.dist_url, world_size=args.world_size, rank=args.rank, timeout=timedelta(days=10),
+    #)
+
+    deepspeed.init_distributed()
     dist.barrier()
     setup_for_distributed(args.rank == 0)


### PR DESCRIPTION
1. Add deepspeed support, including config json and launch shell. Zero2 and fp16 are in use by default.
2. fix some errors introduced by colossalai zero(the import path, indeed). Now `--use_colo_zero` is store_true, for passing a bool value is not allowed in the shell script.
3. disable some logging warnings, for BatchEncoder is used in the model, but not supported fp16. It will turn to fp32 automatically.